### PR TITLE
Update easylist_pac.py

### DIFF
--- a/easylist_pac.py
+++ b/easylist_pac.py
@@ -47,7 +47,7 @@ try:
            **{'fontset': 'custom', 'rm': 'sans:bold', 'bf': 'sans:bold', 'it': 'sans:italic', 'sf': 'sans:bold',
               'default': 'it'})
     # plt.rc('text',usetex=False) # [default] usetex should be False
-    mpl.rcParams['text.latex.preamble'] = [r'\\usepackage{amsmath,sfmath} \\boldmath']
+    mpl.rcParams['text.latex.preamble'] = r'\\usepackage{amsmath,sfmath} \\boldmath'
 except ImportError as e:
     plot_flag = False
     print(e)


### PR DESCRIPTION
In future versions of Matplotlib, having 'text.latex.preamble' as a list isn't possible.

```
easylist_pac.py:50: MatplotlibDeprecationWarning: Support for setting the 'text.latex.preamble' or 'pgf.preamble' rcParam to a list of strings is deprecated since 3.3 and will be removed two minor releases later; set it to a single string instead.
  mpl.rcParams['text.latex.preamble'] = [r'\\usepackage{amsmath,sfmath} \\boldmath']
```